### PR TITLE
feat: make MCP Server stateful for multiple serverless container

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,6 +40,7 @@
   },
   "cSpell.language": "en-US",
   "cSpell.words": [
+    "AWSS",
     "buildkitd",
     "buildx",
     "CERTDIR",
@@ -55,6 +56,7 @@
     "modelcontextprotocol",
     "oninitialized",
     "PKCE",
+    "resumability",
     "rspack",
     "Streamable",
     "tsparser",

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A playground for Model Context Protocol (MCP) server built with TypeScript and S
 - MCP Server implementation: HTTP-Based Streamable transport using `@modelcontextprotocol/sdk` with HTTP transport, session management, and tool execution.
 - OAuth authentication/3rd party authorization: Implements an OAuth server for MCP clients to process 3rd party authorization servers like Auth0, providing Dynamic Application Registration for MCP server.
 - Storage: Provide storage for MCP server to store data like OAuth sessions, tokens, etc.
-- Session Management: MCP server can manage multiple sessions stateless.
+- Session Management: Support stateful sessions by using replay of initial request.
 - Tools: `echo`, `system-time`, `streaming`, `project` for demonstration.
 - Prompts: `echo`
 
@@ -132,6 +132,20 @@ helm install mcp-server-playground chrisleekr/mcp-server-playground
      - JSON Web Token (JWT) Profile: Auth0
      - JSON Web Token (JWT) Signature Algorithm: RS256
    - Click on "Create"
+
+## How to make stateful session with multiple MCP Server instances?
+
+When the MCP server is deployed as a cluster, it is not possible to make it stateful with multiple MCP Server instances because the transport is not shared between instances by design.
+
+To make it truly stateful, I used Valkey to store the session id with the initial request.
+
+When the request comes in to alternative MCP server instance, it will check if the session id is in the Valkey. If it is, it will replay the initial request and connect the transport to the server.
+
+Inspired from [https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/102](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/102)
+
+The below diagram shows the flow of the stateful session management.
+
+<img width="681" height="882" alt="Image" src="https://github.com/user-attachments/assets/7f56339e-2665-47cb-a882-69d3c7096b47" />
 
 ## TODO
 

--- a/src/core/server/http/handlers/mcpDelete.ts
+++ b/src/core/server/http/handlers/mcpDelete.ts
@@ -19,7 +19,7 @@ export function setupMCPDeleteHandler(
         if (
           sessionId === undefined ||
           sessionId.trim() === '' ||
-          !(await transportManager.hasTransport(sessionId))
+          !(await transportManager.hasSession(sessionId))
         ) {
           loggingContext.log('error', 'Session not found');
           res.status(200).json({ error: 'Session not found' }); // Return 200 to gracefully handle the request
@@ -27,7 +27,7 @@ export function setupMCPDeleteHandler(
         }
 
         loggingContext.log('debug', 'Found session, getting transport');
-        const transport = await transportManager.getTransport(sessionId);
+        const transport = transportManager.getTransport(sessionId);
         if (!transport) {
           loggingContext.log('error', 'Transport not found');
           res.status(200).json({ error: 'Transport not found' }); // Return 200 to gracefully handle the request

--- a/src/tools/aws/s3/index.ts
+++ b/src/tools/aws/s3/index.ts
@@ -1,0 +1,179 @@
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+import { loggingContext, sendProgressNotification } from '@/core/server';
+import {
+  createStructuredContent,
+  Tool,
+  ToolBuilder,
+  ToolContext,
+  ToolInputSchema,
+  ToolResult,
+} from '@/tools/types';
+
+import packageJson from '../../../../package.json';
+import { AWSS3Input, AWSS3InputSchema, AWSS3Output } from './types';
+
+async function* executeAWSS3(
+  input: AWSS3Input,
+  context: ToolContext
+): AsyncGenerator<ToolResult & { data?: AWSS3Output }> {
+  const progressToken = context.progressToken;
+
+  loggingContext.log('info', `Progress token: ${progressToken}`);
+
+  loggingContext.setContextValue('tool', 'aws-s3');
+  const startTime = Date.now();
+
+  try {
+    loggingContext.log('debug', 'Executing echo tool', { data: { input } });
+
+    // Send mid-progress notification
+    if (context.server) {
+      await sendProgressNotification(context.server, {
+        progressToken,
+        progress: 0,
+        total: 100,
+        message: 'Starting echo tool',
+      });
+    }
+
+    // Validate input using Zod schema
+    const validatedInput = AWSS3InputSchema.parse(input);
+
+    // TODO: Do something
+
+    if (context.server) {
+      await sendProgressNotification(context.server, {
+        progressToken,
+        progress: 100,
+        total: 100,
+        message: 'AWS S3 tool completed',
+      });
+    }
+
+    // TODO: Prepare output
+    const output: AWSS3Output = {
+      bucket: validatedInput.bucket,
+      key: validatedInput.key,
+      content: 'Hello, world!',
+    };
+
+    // Create a resource link
+    const executionTime = Date.now() - startTime;
+
+    // Create structured content for the new MCP spec
+    const structuredOutput = createStructuredContent(
+      output,
+      {
+        type: 'object',
+        properties: {
+          bucket: {
+            type: 'string',
+            description: 'The name of the S3 bucket',
+          },
+          key: {
+            type: 'string',
+            description: 'The key of the S3 object',
+          },
+          content: {
+            type: 'string',
+            description: 'The content of the S3 object',
+          },
+        },
+        required: ['bucket', 'key', 'content'],
+      },
+      'json'
+    );
+
+    loggingContext.log('info', 'AWS S3 tool executed successfully', {
+      data: {
+        bucket: input.bucket,
+        key: input.key,
+        executionTime,
+      },
+    });
+
+    yield {
+      success: true,
+      executionTime,
+      timestamp: new Date().toISOString(),
+      metadata: {
+        toolVersion: packageJson.version,
+        mcpSpecVersion: '2025-06-18',
+      },
+      data: output,
+      structuredContent: structuredOutput,
+    };
+  } catch (error) {
+    const executionTime = Date.now() - startTime;
+    const errorMessage =
+      error instanceof Error ? error.message : 'Unknown error occurred';
+
+    loggingContext.log('error', 'AWS S3 tool execution failed', {
+      data: {
+        error: {
+          message: errorMessage,
+          stack: error instanceof Error ? error.stack : undefined,
+        },
+        input,
+        executionTime,
+      },
+    });
+
+    yield {
+      success: false,
+      error: errorMessage,
+      executionTime,
+      timestamp: new Date().toISOString(),
+      metadata: {
+        toolVersion: packageJson.version,
+        inputValidation: 'failed',
+      },
+    };
+  }
+}
+
+/**
+ * Create and export the AWS S3 tool
+ */
+export const awsS3Tool: Tool<AWSS3Input, AWSS3Output> = new ToolBuilder<
+  AWSS3Input,
+  AWSS3Output
+>('aws-s3')
+  .description('Get the content of an S3 object')
+  .inputSchema(zodToJsonSchema(AWSS3InputSchema) as typeof ToolInputSchema)
+  .outputSchema({
+    type: 'object',
+    properties: {
+      bucket: { type: 'string', description: 'The name of the S3 bucket' },
+      key: { type: 'string', description: 'The key of the S3 object' },
+      content: { type: 'string', description: 'The content of the S3 object' },
+    },
+  })
+  .examples([
+    {
+      input: { bucket: 'my-bucket', key: 'my-key' },
+      output: {
+        success: true,
+        data: {
+          bucket: 'my-bucket',
+          key: 'my-key',
+          content: 'Hello, world!',
+        },
+        structuredContent: {
+          type: 'structured',
+          content: {
+            bucket: 'my-bucket',
+            key: 'my-key',
+            content: 'Hello, world!',
+          },
+        },
+      },
+      description: 'Get the content of an S3 object',
+    },
+  ])
+  .tags(['aws', 's3', 'storage'])
+  .version(packageJson.version)
+  .timeout(2000)
+  .streamingImplementation(executeAWSS3)
+  .build();

--- a/src/tools/aws/s3/types.ts
+++ b/src/tools/aws/s3/types.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const AWSS3InputSchema = z.object({
+  bucket: z.string().describe('The name of the S3 bucket'),
+  key: z.string().describe('The key of the S3 object'),
+});
+
+export type AWSS3Input = z.infer<typeof AWSS3InputSchema>;
+
+export interface AWSS3Output {
+  bucket: string;
+  key: string;
+  content: string;
+}

--- a/src/tools/loader.ts
+++ b/src/tools/loader.ts
@@ -2,6 +2,7 @@ import { loggingContext } from '@/core/server';
 import { toolRegistry } from '@/tools/registry';
 import { Tool, ToolDefinition } from '@/tools/types';
 
+import { awsS3Tool } from './aws/s3';
 import { echoTool } from './echo';
 import { projectTool } from './project';
 import { streamingTool } from './streaming';
@@ -36,6 +37,9 @@ export class ToolLoader {
 
       // Register project tool
       this.registerTool(projectTool);
+
+      // Register AWS S3 tool
+      this.registerTool(awsS3Tool);
 
       this.loaded = true;
       loggingContext.log('info', 'Successfully loaded tools');


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline when developing.
-->

## Description

<!-- Describe your changes in detail -->

In the previous PR #36, I made MCP Server to be stateless. However, if I make the stateless, session id is not able to track because it does not keep the session id.

However, in the stateful MCP server, the transport only kept in the initialised container. If there are multiple containers, the transport is not shared between the containers. 

To make stateful MCP server + multiple serveless container, I updated transport to be able to replay initial request along session id in Valkey.

This is the diagram to achieve the stateful MCP server across multiple containers.

<img width="681" height="882" alt="20250802 MCP Server Stateful Session Management drawio" src="https://github.com/user-attachments/assets/08faaf75-daed-4e51-83aa-23de00c07323" />



## Related Issues

<!-- Link any related issues here -->

- Closes #(issue number)

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## Screenshots/Recordings

<!-- Add screenshots or recordings if your changes affect the UI -->
